### PR TITLE
feat(headers): removed multiple namespace

### DIFF
--- a/include/trac_ik/kdl_tl.hpp
+++ b/include/trac_ik/kdl_tl.hpp
@@ -35,7 +35,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kdl/chainfksolverpos_recursive.hpp>
 #include <kdl/chainiksolvervel_pinv.hpp>
 
-namespace TRAC_IK
+namespace trac_ik
 {
 class TRAC_IK;
 }
@@ -47,7 +47,7 @@ enum BasicJointType { RotJoint, TransJoint, Continuous };
 
 class ChainIkSolverPos_TL
 {
-  friend class TRAC_IK::TRAC_IK;
+  friend class trac_ik::TRAC_IK;
 
 public:
   ChainIkSolverPos_TL(const Chain& chain, const JntArray& q_min, const JntArray& q_max, double maxtime = 0.005, double eps = 1e-3, bool random_restart = false, bool try_jl_wrap = false);

--- a/include/trac_ik/nlopt_ik.hpp
+++ b/include/trac_ik/nlopt_ik.hpp
@@ -36,7 +36,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <nlopt.hpp>
 
 
-namespace NLOPT_IK
+namespace trac_ik
 {
 
 enum OptType { Joint, DualQuat, SumSq, L2 };
@@ -44,7 +44,7 @@ enum OptType { Joint, DualQuat, SumSq, L2 };
 
 class NLOPT_IK
 {
-  friend class TRAC_IK::TRAC_IK;
+  friend class trac_ik::TRAC_IK;
 public:
   NLOPT_IK(const KDL::Chain& chain, const KDL::JntArray& q_min, const KDL::JntArray& q_max, double maxtime = 0.005, double eps = 1e-3, OptType type = SumSq);
 

--- a/include/trac_ik/trac_ik.hpp
+++ b/include/trac_ik/trac_ik.hpp
@@ -40,7 +40,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <boost/date_time.hpp>
 
-namespace TRAC_IK
+namespace trac_ik
 {
 
 enum SolveType { Speed, Distance, Manip1, Manip2 };
@@ -84,7 +84,7 @@ public:
   {
     lb = lb_;
     ub = ub_;
-    nl_solver.reset(new NLOPT_IK::NLOPT_IK(chain, lb, ub, maxtime, eps, NLOPT_IK::SumSq));
+    nl_solver.reset(new trac_ik::NLOPT_IK(chain, lb, ub, maxtime, eps, trac_ik::SumSq));
     iksolver.reset(new KDL::ChainIkSolverPos_TL(chain, lb, ub, maxtime, eps, true, true));
     return true;
   }
@@ -116,7 +116,7 @@ private:
   double maxtime;
   SolveType solvetype;
 
-  std::unique_ptr<NLOPT_IK::NLOPT_IK> nl_solver;
+  std::unique_ptr<trac_ik::NLOPT_IK> nl_solver;
   std::unique_ptr<KDL::ChainIkSolverPos_TL> iksolver;
 
   boost::posix_time::ptime start_time;


### PR DESCRIPTION
Removed the multiple namespaces from the code and substitute with `trac_ik` complying with the C++ guidelines for naming